### PR TITLE
Add transaction aware JsonMapping for Parent Child

### DIFF
--- a/src/main/java/com/graphaware/module/es/mapping/BaseMapping.java
+++ b/src/main/java/com/graphaware/module/es/mapping/BaseMapping.java
@@ -40,8 +40,6 @@ public abstract class BaseMapping implements Mapping {
     private static final String DEFAULT_KEY_PROPERTY = "uuid";
     private static final String DEFAULT_FORCE_STRINGS = "false";
 
-    protected ElasticSearchConfiguration configuration;
-
     protected String keyProperty;
     protected String indexPrefix;
     protected boolean forceStrings;
@@ -61,8 +59,6 @@ public abstract class BaseMapping implements Mapping {
 
         forceStrings = config.getOrDefault("forceStrings", DEFAULT_FORCE_STRINGS).trim().toLowerCase().equals("true");
         LOG.info("ElasticSearch force-strings set to %s", forceStrings);
-
-        this.configuration = configuration;
     }
 
     /**
@@ -201,10 +197,6 @@ public abstract class BaseMapping implements Mapping {
     }
 
     public abstract <T extends PropertyContainer> String getIndexFor(Class<T> searchedType);
-
-    protected ElasticSearchConfiguration getConfiguration() {
-        return configuration;
-    }
 
     protected List<BulkableAction<? extends JestResult>> emptyActions() {
         return new ArrayList<>();


### PR DESCRIPTION
This is pr is a work in progress. The goal is to get it tested and production ready then try to get it merged into the graphaware master copy (if they want it). It would be easier for everyone if we just contributed to a central source rather than maintain two copies. 

Also I can see this functionality being useful to more people than just us.

Things to note
* Elasticsearch index has to be pre-configured manually before neo4j run (to tell es that there is a parent child relationship)
* The node "type" has to be the same as the neo4j label - in the future we will add a specific neo4j label option
* Edge values are not stored in parent child relationships
* You cannot have more than one type between children nodes and regular nodes

* Code needs to be cleaned up.